### PR TITLE
[FIX] Maximum value assignment

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -44,7 +44,7 @@ function mode( arr, clbk ) {
 		count[ val ] += 1;
 		if ( count[ val ] === max ) {
 			vals.push( val );
-		} else {
+		} else if ( count[ val ] > max ) {
 			max = count[ val ];
 			vals = [ val ];
 		}

--- a/test/test.js
+++ b/test/test.js
@@ -76,6 +76,9 @@ describe( 'compute-mode', function tests() {
 
 		data = [ 2, 4, 5, 3, 8, 4, 2 ];
 		assert.deepEqual( mode( data ), [ 2, 4 ] );
+
+		data = [ 2, 2, 4 ];
+		assert.deepEqual( mode( data ), [ 2 ] );
 	});
 
 	it( 'should compute the mode using an accessor', function test() {
@@ -107,6 +110,17 @@ describe( 'compute-mode', function tests() {
 
 		actual = mode( data, getValue );
 		expected = [ 2, 4 ];
+
+		assert.deepEqual( actual, expected );
+
+		data = [
+			{'x':2},
+			{'x':2},
+			{'x':4}
+		];
+
+		actual = mode( data, getValue );
+		expected = [ 2 ];
 
 		assert.deepEqual( actual, expected );
 


### PR DESCRIPTION
The maximum should only be assigned if the count of the current value is greater than the maximum, not every time it is not the same. The current test cases only return the correct results because the modes happen to be the last values of their respective input sets.
